### PR TITLE
Add glyph mapping function

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Load, validate, manipulate, and write font files for [Glyphs](http://glyphsapp.c
 
 ## ⚠️ Work in Progress ⚠️
 
-The API described below is functional but may change. Testing and contributions are welcome. Planned features include merging multiple files, subsetting glyphs, and mapping glyphs to new unicode positions.
+The API described below is functional but may change. Testing and contributions are welcome. Planned features include merging multiple files and subsetting glyphs.
 
 
 ## Install
@@ -28,6 +28,12 @@ GLYPHS.load('my-font.glyphs')
 
 ## API
 
+- [`.load(filepath)`](#-load-filepath-)
+- [`.map(fontdata, mapping, [options])`](#-map-fontdata-mapping-options-)
+- [`.validate(fontdata)`](#-validate-fontdata-)
+- [`.version(fontdata, [type])`](#-version-fontdata-type-)
+- [`.write(filepath, fontdata, [options])`](#-write-filepath-fontdata-options-)
+
 
 ### .load(filepath)
 
@@ -40,6 +46,46 @@ GLYPHS.load('my-font.glyphs')
   .then(fontdata => {
     console.log(fontdata)
   })
+```
+
+
+### .map(fontdata, mapping, [options])
+
+- `fontdata` — an `Object` representing a Glyphs file.
+
+- `mapping` — an `Object` mapping source glyphs to destination glyphs. Keys should be unicode strings, e.g. `'0041'`, and values either a unicode string or an array of unicode strings, i.e. `'0061'` or `['0061', '0040']`.
+
+- `options` — an optional `Object` with any of the following properties
+  - `includeUnmappedGlyphs` — `Boolean` (default: `false`) If true, preserves any glyphs from the `fontdata` not included in `mapping`. Otherwise, these are discarded.
+  - `renameGlyphs` — `Boolean` (default: `true`) If `true`, tries to rename a mapped glyph using [`readable-glyph-names`](https://github.com/delucis/readable-glyph-names).
+  - `selectSourceByGlyphName` — `Boolean` (default: `false`) If `true`, uses the `glyphname` property to select source glyphs. Otherwise, the `unicode` property is used. When `true`, `mapping` might look like `{ A: '0061' }` instead of `{ '0041': '0061' }.`
+
+Returns a font data `Object`, in which glyphs from the input `fontdata` are mapped to new unicode positions.
+
+```js
+let font = {
+  glyphs: [
+    {
+      glyphname: 'A',
+      layers: [ /* ... */ ],
+      unicode: '0041'
+    }
+  ]
+  /* ... */
+}
+
+let mappedFont = GLYPHS.map(font, { '0041': '007A' })
+console.log(mappedFont)
+// => {
+//   glyphs: [
+//     {
+//       glyphname: 'z',
+//       layers: [ /* ... */ ],
+//       unicode: '007A'
+//     }
+//   ]
+//   /* ... */
+// }
 ```
 
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const LOAD_PLIST = require('load-nextstep-plist')
 const WRITE_GLYPHS = require('write-glyphs-file')
+const MAP = require('./lib/map')
 const VALIDATE = require('./lib/validate')
 const VERSION = require('./lib/version')
 
@@ -7,6 +8,7 @@ const LOAD = async fp => LOAD_PLIST(fp).then(VALIDATE)
 const WRITE = async (fp, g, o) => VALIDATE(g).then(g => WRITE_GLYPHS(fp, g, o))
 
 module.exports.load = LOAD
+module.exports.map = MAP
 module.exports.validate = VALIDATE
 module.exports.version = VERSION
 module.exports.write = WRITE

--- a/lib/map.js
+++ b/lib/map.js
@@ -1,0 +1,62 @@
+const CLONE_DEEP = require('lodash.clonedeep')
+const GLYPHNAMES = require('readable-glyph-names')
+
+/**
+ * Map glyphs of a font data object to different unicode positions.
+ * @param  {Object}  fontdata                        Font data
+ * @param  {Object}  map                             Source to dest. glyph map
+ * @param  {Boolean} [map.renameGlyphs=true]
+ * @param  {Boolean} [map.selectSourceByGlyphName=false]
+ * @param  {Boolean} [map.includeUnmappedGlyphs=false]
+ * @return {Object}                                  Font data
+ */
+module.exports = (
+  fontdata,
+  map,
+  {
+    renameGlyphs = true,
+    selectSourceByGlyphName = false,
+    includeUnmappedGlyphs = false
+  } = {}
+) => {
+  fontdata = CLONE_DEEP(fontdata)
+  let srcKey = selectSourceByGlyphName ? 'glyphname' : 'unicode'
+
+  let glyphMap = fontdata.glyphs.reduce((glyphs, glyph) => {
+    glyphs[glyph[srcKey]] = glyph
+    return glyphs
+  }, {})
+
+  let newGlyphs = Object.entries(map).reduce((newGlyphs, [ src, dest ]) => {
+    let srcGlyph = glyphMap[src]
+    dest = Array.isArray(dest) ? dest : [dest]
+
+    dest.forEach(d => {
+      let glyph = CLONE_DEEP(srcGlyph)
+      glyph.unicode = d
+
+      if (renameGlyphs && GLYPHNAMES[d]) glyph.glyphname = GLYPHNAMES[d]
+
+      if (includeUnmappedGlyphs) {
+        let glyphAtDest
+        if (selectSourceByGlyphName) {
+          glyphAtDest = fontdata.glyphs.find(g => g.unicode === d)
+        } else {
+          glyphAtDest = glyphMap[d]
+        }
+        if (glyphAtDest) delete glyphMap[glyphAtDest[srcKey]]
+      }
+
+      newGlyphs.push(glyph)
+    })
+
+    if (includeUnmappedGlyphs) delete glyphMap[src]
+
+    return newGlyphs
+  }, [])
+
+  if (includeUnmappedGlyphs) newGlyphs.push(...Object.values(glyphMap))
+
+  fontdata.glyphs = newGlyphs
+  return fontdata
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6930,6 +6930,11 @@
         "read-pkg": "2.0.0"
       }
     },
+    "readable-glyph-names": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/readable-glyph-names/-/readable-glyph-names-1.0.0.tgz",
+      "integrity": "sha512-9FyaKaSlriOVquFJQdUhPHOwHDVw6AXzV6gDJ/f8cXxf7QMbMpv6FBc/pnf+bCZGZ67YytCnCbmqgSCEijghqg=="
+    },
     "readable-stream": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "joi": "^13.2.0",
     "load-nextstep-plist": "^1.0.2",
     "lodash.clonedeep": "^4.5.0",
+    "readable-glyph-names": "^1.0.0",
     "write-glyphs-file": "^1.0.1"
   },
   "devDependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -15,6 +15,81 @@ test('fail to validate', async test => {
   test.is(err.name, 'ValidationError')
 })
 
+test('map A to a by unicode', async test => {
+  const data = await makeGlyphs.load(testGlyphs)
+  const A = data.glyphs.find(g => g.unicode === '0041')
+  const { glyphs } = makeGlyphs.map(data, { '0041': '0061' })
+  test.deepEqual(glyphs.find(g => g.glyphname === 'a').layers, A.layers)
+})
+
+test('map B to z by glyphname', async test => {
+  const data = await makeGlyphs.load(testGlyphs)
+  const B = data.glyphs.find(g => g.glyphname === 'B')
+  const { glyphs } = makeGlyphs.map(data, { B: '007A' }, { selectSourceByGlyphName: true })
+  test.deepEqual(glyphs.find(g => g.glyphname === 'z').layers, B.layers)
+})
+
+test('map A to a and z by unicode', async test => {
+  const data = await makeGlyphs.load(testGlyphs)
+  const A = data.glyphs.find(g => g.unicode === '0041')
+  const { glyphs } = makeGlyphs.map(data, { '0041': ['0061', '007A'] })
+  test.deepEqual(glyphs.find(g => g.glyphname === 'a').layers, A.layers)
+  test.deepEqual(glyphs.find(g => g.glyphname === 'z').layers, A.layers)
+})
+
+test('map B to z but don’t rename', async test => {
+  const data = await makeGlyphs.load(testGlyphs)
+  const B = data.glyphs.find(g => g.glyphname === 'B')
+  const { glyphs } = makeGlyphs.map(data, { '0042': '007A' }, { renameGlyphs: false })
+  test.deepEqual(glyphs.find(g => g.unicode === '007A').layers, B.layers)
+})
+
+test('empty map returns empty glyphs', async test => {
+  const data = await makeGlyphs.load(testGlyphs)
+  const { glyphs } = makeGlyphs.map(data, {})
+  test.is(glyphs.length, 0)
+})
+
+test('includeUnmappedGlyphs preserves unmapped glyphs with empty map', async test => {
+  const data = await makeGlyphs.load(testGlyphs)
+  const length = data.glyphs.length
+  const K = data.glyphs.find(g => g.unicode === '004B')
+  const { glyphs } = makeGlyphs.map(data, {}, { includeUnmappedGlyphs: true })
+  test.is(glyphs.length, length)
+  test.deepEqual(glyphs.find(g => g.glyphname === 'K'), K)
+})
+
+test('includeUnmappedGlyphs preserves unmapped glyphs when mapping other glyphs', async test => {
+  const data = await makeGlyphs.load(testGlyphs)
+  const length = data.glyphs.length
+  const A = data.glyphs.find(g => g.unicode === '0041')
+  const K = data.glyphs.find(g => g.unicode === '004B')
+  const { glyphs } = makeGlyphs.map(data, { '0041': '0061' }, { includeUnmappedGlyphs: true })
+  test.is(glyphs.length, length)
+  test.deepEqual(glyphs.find(g => g.glyphname === 'K'), K)
+  test.deepEqual(glyphs.find(g => g.glyphname === 'a').layers, A.layers)
+})
+
+test('glyph mapping overwrites existing glyphs with includeUnmappedGlyphs', async test => {
+  const data = await makeGlyphs.load(testGlyphs)
+  const length = data.glyphs.length
+  const A = data.glyphs.find(g => g.unicode === '0041')
+  const { glyphs } = makeGlyphs.map(data, { '0041': '004B' }, { includeUnmappedGlyphs: true })
+  test.is(glyphs.length, length - 1)
+  test.is(glyphs.filter(g => g.glyphname === 'K').length, 1)
+  test.deepEqual(glyphs.find(g => g.glyphname === 'K').layers, A.layers)
+})
+
+test('glyph mapping overwrites existing glyphs with includeUnmappedGlyphs and selectSourceByGlyphName', async test => {
+  const data = await makeGlyphs.load(testGlyphs)
+  const length = data.glyphs.length
+  const A = data.glyphs.find(g => g.unicode === '0041')
+  const { glyphs } = makeGlyphs.map(data, { A: '004B' }, { includeUnmappedGlyphs: true, selectSourceByGlyphName: true })
+  test.is(glyphs.length, length - 1)
+  test.is(glyphs.filter(g => g.glyphname === 'K').length, 1)
+  test.deepEqual(glyphs.find(g => g.glyphname === 'K').layers, A.layers)
+})
+
 test('increment versions', async test => {
   const data = await makeGlyphs.load(testGlyphs)
   test.is(data.versionMajor, 1)

--- a/test/test.js
+++ b/test/test.js
@@ -10,7 +10,7 @@ test('load & validate file', async test => {
   test.is(data.familyName, 'Test Font')
 })
 
-test('fail to validate', async test => {
+test('load & fail to validate', async test => {
   const err = await test.throws(makeGlyphs.load(testPlist))
   test.is(err.name, 'ValidationError')
 })


### PR DESCRIPTION
Signature: `.map(fontdata, mapping, [options])`

Allows a user to map glyphs to one or more different unicode positions.