### PR TITLE
Add .set(), .build() and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,50 @@ GLYPHS.load('my-font.glyphs')
 
 ## API
 
+- [`.build(builds)`](#buildbuilds)
 - [`.load(filepath)`](#loadfilepath)
 - [`.map(fontdata, mapping, [options])`](#mapfontdata-mapping-options)
+- [`.set(fontdata, key, value)`](#setfontdata-key-value)
 - [`.subset(fontdata, subset)`](#subsetfontdata-subset)
 - [`.validate(fontdata)`](#validatefontdata)
 - [`.version(fontdata, [type])`](#versionfontdata-type)
 - [`.write(filepath, fontdata, [options])`](#writefilepath-fontdata-options)
+
+
+### .build(builds)
+
+- `builds` — an `Object` specifying a full build task. It should contain at least one `Object`, defining a build:
+
+  - Each object in `builds` should have the following properties:
+
+    - `load` — a `String` specifying the source file to load
+    - `process` (optional) — an `Array` of tasks to run. Each task should be defined as follows: `[ taskType, arguments... ]`, e.g. `['set', 'familyName', 'New Name']`.
+    - `write` — a `String` specifying the path to write the new font to
+
+`.build()` provides a way to specify an entire font-processing task, loading, processing, and saving a font, using a Javascript object to specify all the steps.
+
+```js
+const MY_BUILDS = {
+  myBuild: {
+    load: 'my-font.glyphs',
+    process: [
+      ['subset', [['0041', '0061']]],
+      ['set', 'familyName', 'My Subset Font'],
+      ['version']
+    ],
+    write: 'my-subset-font.glyphs'
+  }
+}
+
+GLYPHS.build(MY_BUILDS)
+
+// The above is equivalent to:
+GLYPHS.load('my-font.glyphs')
+  .then(font => GLYPHS.subset(font, [['0041', '0061']]))
+  .then(font => GLYPHS.set(font, 'familyName', 'My Subset Font'))
+  .then(GLYPHS.version)
+  .then(font => GLYPHS.write('my-subset-font.glyphs', font))
+```
 
 
 ### .load(filepath)
@@ -94,6 +132,28 @@ console.log(mappedFont)
 //     }
 //   ]
 //   /* ... */
+// }
+```
+
+
+### .set(fontdata, key, value)
+
+- `fontdata` — an `Object` representing a Glyphs file
+
+- `key` — the key in the `fontdata` to set as a `String`
+
+- `value` — the value to set the key to, can be any Javascript type. If a `Function` is passed, it will be called with the current value (if present) as its first argument and the entire `fontdata` representation as its second argument.
+
+This allows you to directly set a root property of the `fontdata`. This can also be achieved with simple assignment, i.e. `fontdata.familyName = 'New Name'`, but sometimes the `.set()` helper may be more convenient.
+
+```js
+let fontdata = { familyName: 'Lemons' }
+
+GLYPHS.set(fontdata, 'designer', 'Proud Parent')
+GLYPHS.set(fontdata, 'familyName', name => `Updated ${name}`)
+// fontdata = {
+//   designer: 'Proud Parent',
+//   familyName: 'Updated Lemons'
 // }
 ```
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ GLYPHS.load('my-font.glyphs')
 
   - `renameGlyphs` — `Boolean` (default: `true`) If `true`, tries to rename a mapped glyph using [`readable-glyph-names`](https://github.com/delucis/readable-glyph-names).
 
-  - `selectSourceByGlyphName` — `Boolean` (default: `false`) If `true`, uses the `glyphname` property to select source glyphs. Otherwise, the `unicode` property is used. When `true`, `mapping` might look like `{ A: '0061' }` instead of `{ '0041': '0061' }.`
+  - `selectSourceByGlyphName` — `Boolean` (default: `false`) If `true`, uses the `glyphname` property to select source glyphs. Otherwise, the `unicode` property is used. When `true`, `mapping` might look like `{ A: '0061' }` instead of `{ '0041': '0061' }`.
 
 Returns a font data `Object`, in which glyphs from the input `fontdata` are mapped to new unicode positions.
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,0 +1,55 @@
+#! /usr/bin/env node
+const FS = require('fs')
+const PATH = require('path')
+const BUILD = require('../').build
+const V = require('../package.json').version
+const ARGS = require('minimist')(process.argv.slice(2), {
+  alias: {
+    b: 'build',
+    c: 'config',
+    h: 'help',
+    v: 'version'
+  },
+  boolean: ['h', 'v'],
+  default: {
+    c: 'glyphs.config.js'
+  }
+})
+
+if (ARGS.help) {
+  console.log(`
+    Description
+      Processes .glyphs files according to your config file
+    Usage
+      $ make-glyphs [options]
+    Options
+      --build, -b <name>    Only run the named build in your config file
+      --config, -c <file>   The path to your config file, default: glyphs.config.js
+      --help, -h            Displays this message
+      --version, -v         Display the version of make-glyphs you are using
+  `)
+  process.exit(0)
+}
+
+if (ARGS.version) {
+  console.log(V)
+  process.exit(0)
+}
+
+const ROOT = PATH.resolve(ARGS._[0] || '.')
+const CONFIGFILE = PATH.resolve(ROOT, ARGS.config)
+
+let config = {}
+if (FS.existsSync(CONFIGFILE)) {
+  config = require(CONFIGFILE)
+} else {
+  console.error(`Could not find config file ${ARGS.config}`)
+  process.exit(1)
+}
+
+if (!config.builds) {
+  console.error(`Config file does not contain a “builds” object`)
+  process.exit(1)
+}
+BUILD(config.builds)
+

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+module.exports.build = require('./lib/build')
 module.exports.load = require('./lib/load')
 module.exports.map = require('./lib/map')
 module.exports.subset = require('./lib/subset')

--- a/index.js
+++ b/index.js
@@ -1,16 +1,6 @@
-const LOAD_PLIST = require('load-nextstep-plist')
-const WRITE_GLYPHS = require('write-glyphs-file')
-const MAP = require('./lib/map')
-const SUBSET = require('./lib/subset')
-const VALIDATE = require('./lib/validate')
-const VERSION = require('./lib/version')
-
-const LOAD = async fp => LOAD_PLIST(fp).then(VALIDATE)
-const WRITE = async (fp, g, o) => VALIDATE(g).then(g => WRITE_GLYPHS(fp, g, o))
-
-module.exports.load = LOAD
-module.exports.map = MAP
-module.exports.subset = SUBSET
-module.exports.validate = VALIDATE
-module.exports.version = VERSION
-module.exports.write = WRITE
+module.exports.load = require('./lib/load')
+module.exports.map = require('./lib/map')
+module.exports.subset = require('./lib/subset')
+module.exports.validate = require('./lib/validate')
+module.exports.version = require('./lib/version')
+module.exports.write = require('./lib/write')

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 module.exports.build = require('./lib/build')
 module.exports.load = require('./lib/load')
 module.exports.map = require('./lib/map')
+module.exports.set = require('./lib/set')
 module.exports.subset = require('./lib/subset')
 module.exports.validate = require('./lib/validate')
 module.exports.version = require('./lib/version')

--- a/lib/build.js
+++ b/lib/build.js
@@ -1,0 +1,54 @@
+const TASKS = new Set(['map', 'set', 'subset', 'validate', 'version'])
+const FUNCTIONS = new Set([...TASKS, 'load', 'write'])
+const G = [...FUNCTIONS].reduce((obj, fn) => {
+  obj[fn] = require(`./${fn}`)
+  return obj
+}, {})
+
+const run = (data, tasks) => {
+  return tasks.reduce((fontdata, [task, ...args]) => {
+    if (TASKS.has(task)) return G[task](fontdata, ...args)
+    console.warn(`Task type “${task}” is unknown, should be one of “map”, “set”, “subset”, “validate”, or “version”.`)
+    return fontdata
+  }, data)
+}
+
+module.exports = async builds => {
+  await Promise.all(Object.entries(builds).map(async ([name, build]) => {
+    console.log(`Running build “${name}”...`)
+    if (!build.hasOwnProperty('load')) {
+      throw new TypeError(`Build “${name}” must have a load property!`)
+    }
+    if (!build.hasOwnProperty('write')) {
+      throw new TypeError(`Build “${name}” must have a write property!`)
+    }
+
+    let sources = []
+    if (typeof build.load === 'string') {
+      sources.push(G.load(build.load))
+    } else if (Array.isArray(build.load)) {
+      sources = build.load.map(G.load)
+    } else {
+      sources = Object.entries(build.load).map(async ([file, tasks]) => {
+        return G.load(file).then(fontdata => run(fontdata, tasks))
+      })
+    }
+    sources = await Promise.all(sources)
+
+    let merged
+    if (sources.length > 1) {
+      // TODO: more than one file loaded so merging required
+    } else {
+      merged = sources[0]
+    }
+
+    let processed = merged
+    if (build.process) {
+      processed = run(processed, build.process)
+    }
+
+    console.log(`Writing to ${build.write}...`)
+    return G.write(build.write, processed)
+      .then(() => console.log(`Finished build “${name}”!`))
+  }))
+}

--- a/lib/load.js
+++ b/lib/load.js
@@ -1,0 +1,4 @@
+const LOAD_PLIST = require('load-nextstep-plist')
+const VALIDATE = require('./validate')
+
+module.exports = async fp => LOAD_PLIST(fp).then(VALIDATE)

--- a/lib/set.js
+++ b/lib/set.js
@@ -1,0 +1,18 @@
+/**
+ * Set a value for a key of an object
+ * @param  {Object} fontdata A font data object
+ * @param  {String} key      A key to set
+ * @param  {Array}  args     Arguments: value to set, function to get value, etc
+ * @return {Object}          An updated font data object
+ */
+module.exports = (fontdata, key, ...args) => {
+  if (args.length > 1) {
+    fontdata[key] = args
+  } else if (typeof args[0] === 'function') {
+    let currentVal = fontdata.hasOwnProperty(key) ? fontdata[key] : null
+    fontdata[key] = args[0](currentVal, fontdata)
+  } else {
+    fontdata[key] = args[0]
+  }
+  return fontdata
+}

--- a/lib/write.js
+++ b/lib/write.js
@@ -1,0 +1,4 @@
+const WRITE_GLYPHS = require('write-glyphs-file')
+const VALIDATE = require('./validate')
+
+module.exports = async (fp, g, o) => VALIDATE(g).then(g => WRITE_GLYPHS(fp, g, o))

--- a/package-lock.json
+++ b/package-lock.json
@@ -3748,10 +3748,9 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "minipass": {
       "version": "2.2.4",
@@ -3788,6 +3787,14 @@
       "dev": true,
       "requires": {
         "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
       }
     },
     "ms": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7740,6 +7740,22 @@
         }
       }
     },
+    "temp-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
+      "integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
+      "dev": true
+    },
+    "tempy": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-0.2.1.tgz",
+      "integrity": "sha512-LB83o9bfZGrntdqPuRdanIVCPReam9SOZKW0fOy5I9X3A854GGWi0tjCqoXEk84XIEYBc/x9Hq3EFop/H5wJaw==",
+      "dev": true,
+      "requires": {
+        "temp-dir": "1.0.0",
+        "unique-string": "1.0.0"
+      }
+    },
     "term-size": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "lib/*",
     "index.js"
   ],
+  "bin": {
+    "make-glyphs": "bin/cli.js"
+  },
   "keywords": [
     "glyphs",
     "fonts",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "ava": "^0.25.0",
     "coveralls": "^3.0.0",
-    "nyc": "^11.7.1"
+    "nyc": "^11.7.1",
+    "tempy": "^0.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "joi": "^13.2.0",
     "load-nextstep-plist": "^1.0.2",
     "lodash.clonedeep": "^4.5.0",
+    "minimist": "^1.2.0",
     "readable-glyph-names": "^1.0.0",
     "unicode-blocks": "^2.0.4",
     "write-glyphs-file": "^1.0.1"

--- a/test/test.build.js
+++ b/test/test.build.js
@@ -1,0 +1,144 @@
+import path from 'path'
+import test from 'ava'
+import tempy from 'tempy'
+import makeGlyphs from '../'
+
+const testGlyphs = path.join(__dirname, 'test.glyphs')
+
+test('run a simple build', async test => {
+  const builds = {
+    'run a simple build': {
+      load: {
+        'test/test.glyphs': [
+          ['subset', ['0041', '0042']],
+          ['set', 'familyName', 'Subset Font'],
+          ['version']
+        ]
+      },
+      write: tempy.file({extension: 'glyphs'})
+    }
+  }
+  const sourceFont = await makeGlyphs.load(testGlyphs)
+  await makeGlyphs.build(builds)
+  const subsetFont = await makeGlyphs.load(builds['run a simple build'].write)
+  test.is(subsetFont.glyphs.length, 2)
+  test.deepEqual(
+    subsetFont.glyphs.find(g => g.unicode === '0041'),
+    sourceFont.glyphs.find(g => g.unicode === '0041')
+  )
+  test.is(subsetFont.familyName, 'Subset Font')
+  test.is(subsetFont.versionMinor, sourceFont.versionMinor + 1)
+})
+
+test('builds without a load property throw', async test => {
+  const builds = {
+    'builds without a load property throw': { write: '' }
+  }
+  const err = await test.throws(makeGlyphs.build(builds))
+  test.is(err.name, 'TypeError')
+  test.true(err.message.endsWith('must have a load property!'))
+})
+
+test('builds without a write property throw', async test => {
+  const builds = {
+    'builds without a write property throw': { load: 'test/test.glyphs' }
+  }
+  const err = await test.throws(makeGlyphs.build(builds))
+  test.is(err.name, 'TypeError')
+  test.true(err.message.endsWith('must have a write property!'))
+})
+
+test('run a build with a bad task', async test => {
+  const builds = {
+    'run a build with a bad task': {
+      load: {
+        'test/test.glyphs': [
+          ['blame', ['0041', '0042']]
+        ]
+      },
+      write: tempy.file({extension: 'glyphs'})
+    }
+  }
+  const sourceFont = await makeGlyphs.load(testGlyphs)
+  await makeGlyphs.build(builds)
+  const subsetFont = await makeGlyphs.load(builds['run a build with a bad task'].write)
+  test.deepEqual(
+    subsetFont.glyphs.find(g => g.unicode === '0041'),
+    sourceFont.glyphs.find(g => g.unicode === '0041')
+  )
+})
+
+test('run a build with a process property', async test => {
+  const builds = {
+    'run a build with a process property': {
+      load: { 'test/test.glyphs': [] },
+      process: [
+        ['subset', ['0041', '0042']],
+        ['set', 'familyName', 'Subset Font'],
+        ['version']
+      ],
+      write: tempy.file({extension: 'glyphs'})
+    }
+  }
+  const sourceFont = await makeGlyphs.load(testGlyphs)
+  await makeGlyphs.build(builds)
+  const subsetFont = await makeGlyphs.load(builds['run a build with a process property'].write)
+  test.is(subsetFont.glyphs.length, 2)
+  test.deepEqual(
+    subsetFont.glyphs.find(g => g.unicode === '0041'),
+    sourceFont.glyphs.find(g => g.unicode === '0041')
+  )
+  test.is(subsetFont.familyName, 'Subset Font')
+  test.is(subsetFont.versionMinor, sourceFont.versionMinor + 1)
+})
+
+test('run a build where load is an array', async test => {
+  const builds = {
+    'run a build where load is an array': {
+      load: [ 'test/test.glyphs' ],
+      write: tempy.file({extension: 'glyphs'})
+    }
+  }
+  const sourceFont = await makeGlyphs.load(testGlyphs)
+  await makeGlyphs.build(builds)
+  const subsetFont = await makeGlyphs.load(builds['run a build where load is an array'].write)
+  test.deepEqual(
+    subsetFont.glyphs.find(g => g.unicode === '0041'),
+    sourceFont.glyphs.find(g => g.unicode === '0041')
+  )
+  test.is(subsetFont.familyName, sourceFont.familyName)
+})
+
+test('run a build where load is a string', async test => {
+  const builds = {
+    'run a build where load is a string': {
+      load: 'test/test.glyphs',
+      write: tempy.file({extension: 'glyphs'})
+    }
+  }
+  const sourceFont = await makeGlyphs.load(testGlyphs)
+  await makeGlyphs.build(builds)
+  const subsetFont = await makeGlyphs.load(builds['run a build where load is a string'].write)
+  test.deepEqual(
+    subsetFont.glyphs.find(g => g.unicode === '0041'),
+    sourceFont.glyphs.find(g => g.unicode === '0041')
+  )
+  test.is(subsetFont.familyName, sourceFont.familyName)
+})
+
+test.failing('run a build with more than one input file', async test => {
+  const builds = {
+    'run a build with more than one input file': {
+      load: [ 'test/test.glyphs', 'test/test.glyphs' ],
+      write: tempy.file({extension: 'glyphs'})
+    }
+  }
+  const sourceFont = await makeGlyphs.load(testGlyphs)
+  await makeGlyphs.build(builds)
+  const subsetFont = await makeGlyphs.load(builds['run a build with more than one input file'].write)
+  test.deepEqual(
+    subsetFont.glyphs.find(g => g.unicode === '0041'),
+    sourceFont.glyphs.find(g => g.unicode === '0041')
+  )
+  test.is(subsetFont.familyName, sourceFont.familyName)
+})

--- a/test/test.js
+++ b/test/test.js
@@ -3,17 +3,6 @@ import test from 'ava'
 import makeGlyphs from '../'
 
 const testGlyphs = path.join(__dirname, 'test.glyphs')
-const testPlist = path.join(__dirname, 'test.plist')
-
-test('load & validate file', async test => {
-  const data = await makeGlyphs.load(testGlyphs)
-  test.is(data.familyName, 'Test Font')
-})
-
-test('load & fail to validate', async test => {
-  const err = await test.throws(makeGlyphs.load(testPlist))
-  test.is(err.name, 'ValidationError')
-})
 
 test('map A to a by unicode', async test => {
   const data = await makeGlyphs.load(testGlyphs)

--- a/test/test.load.js
+++ b/test/test.load.js
@@ -1,0 +1,16 @@
+import path from 'path'
+import test from 'ava'
+import load from '../lib/load'
+
+const testGlyphs = path.join(__dirname, 'test.glyphs')
+const testPlist = path.join(__dirname, 'test.plist')
+
+test('load & validate file', async test => {
+  const data = await load(testGlyphs)
+  test.is(data.familyName, 'Test Font')
+})
+
+test('load & fail to validate', async test => {
+  const err = await test.throws(load(testPlist))
+  test.is(err.name, 'ValidationError')
+})

--- a/test/test.set.js
+++ b/test/test.set.js
@@ -1,0 +1,21 @@
+import test from 'ava'
+import set from '../lib/set'
+
+test('set family name using a string', test => {
+  test.is(set({}, 'familyName', 'My Font').familyName, 'My Font')
+})
+
+test('set name using a function', test => {
+  let renamedFont = set({ name: 'Gosh' }, 'name', name => `${name} Darn`)
+  test.is(renamedFont.name, 'Gosh Darn')
+})
+
+test('set with more arguments', test => {
+  let setFont = set({}, 'classes', 'x', 'y')
+  test.deepEqual(setFont.classes, ['x', 'y'])
+})
+
+test('set name using a function without existing value', test => {
+  let renamedFont = set({}, 'name', name => `Darn`)
+  test.is(renamedFont.name, 'Darn')
+})

--- a/test/test.write.js
+++ b/test/test.write.js
@@ -1,0 +1,18 @@
+import path from 'path'
+import test from 'ava'
+import tempy from 'tempy'
+import makeGlyphs from '../'
+
+const testGlyphs = path.join(__dirname, 'test.glyphs')
+
+test('loading & writing a .glyphs file', test => {
+  const tempPath = tempy.file({extension: 'glyphs'})
+  let fontdata
+  return makeGlyphs.load(testGlyphs)
+    .then(font => {
+      fontdata = font
+      return makeGlyphs.write(tempPath, fontdata)
+    })
+    .then(() => makeGlyphs.load(tempPath))
+    .then(font => test.deepEqual(font, fontdata))
+})


### PR DESCRIPTION
### Changes
- Create `.set()` function for setting font data values (df878ce, 1107d52)
- Create `.build()` function for running entire build tasks (ca177a4)
- Create a `make-glyphs` CLI, using `.build()` (49a7991)
- Break `.load()` and `.write()` into separate modules (aca06aa)
- Break `.load()` tests into separate modules (aca06aa)
- Write tests for `.write()` (bb6c9d0)
- Update documentation (35db7a1, ab7f9d9)

### New dependencies
- [minimist](https://www.npmjs.com/package/minimist)

#### dev
- [tempy](https://github.com/sindresorhus/tempy)